### PR TITLE
fix(request): don't retry deterministic provider/embedding error codes (#726)

### DIFF
--- a/src/utils/modules/requestWrapper.test.ts
+++ b/src/utils/modules/requestWrapper.test.ts
@@ -244,4 +244,70 @@ describe("apiRequestWrapper", () => {
     expect(retryDecision).toBe(true);
   });
 
+  // #726 — deterministic codes inside otherwise-mixed categories (llm.*, embedding.*)
+  // must not be retried, even though the category short-circuit alone can't reach them.
+  it.each([
+    "llm.provider_auth_failed",
+    "llm.provider_invalid_request",
+    "embedding.provider_auth_failed",
+    "embedding.provider_invalid_request",
+    "embedding.unsupported_input",
+    "embedding.unsupported_dimensions",
+  ] as const)(
+    "does not retry deterministic code %s (#726)",
+    async (code) => {
+      const error = new LlmExeError(`deterministic ${code}`, {
+        code,
+        context: { operation: "test" },
+      });
+      asyncCallWithTimeoutMock.mockRejectedValue(error);
+      backOffMock.mockClear().mockImplementation(async (fn, options) => {
+        try {
+          return await fn();
+        } catch (err) {
+          const shouldRetry = options.retry(err, 1);
+          if (shouldRetry) {
+            return await fn();
+          } else {
+            throw err;
+          }
+        }
+      });
+
+      const apiRequest = setupAPIRequestWrapper();
+      await expect(apiRequest.call(mockMessages)).rejects.toThrow(
+        `deterministic ${code}`
+      );
+
+      const metrics = apiRequest.getMetadata().metrics as any;
+      expect(metrics.total_call_retry).toBe(0);
+      expect(metrics.total_call_error).toBe(1);
+      // handler ran exactly once — the deterministic error was not retried
+      expect(mockHandler).toHaveBeenCalledTimes(1);
+    }
+  );
+
+  it("still retries a transient LlmExeError in a mixed category (embedding.provider_rate_limited) (#726)", async () => {
+    const error = new LlmExeError("rate limited", {
+      code: "embedding.provider_rate_limited",
+      context: { operation: "test" },
+    });
+    asyncCallWithTimeoutMock.mockRejectedValue(error);
+    let retryDecision: boolean | undefined;
+    backOffMock.mockClear().mockImplementation(async (fn, options) => {
+      try {
+        return await fn();
+      } catch (err) {
+        retryDecision = options.retry(err, 1);
+        throw err;
+      }
+    });
+
+    const apiRequest = setupAPIRequestWrapper();
+    await expect(apiRequest.call(mockMessages)).rejects.toThrow("rate limited");
+    // transient code shares the embedding category — must NOT be short-circuited
+    expect(retryDecision).toBe(true);
+    expect((apiRequest.getMetadata().metrics as any).total_call_retry).toBe(1);
+  });
+
 });

--- a/src/utils/modules/requestWrapper.ts
+++ b/src/utils/modules/requestWrapper.ts
@@ -9,7 +9,7 @@ import { backOff } from "exponential-backoff";
 import { asyncCallWithTimeout } from "@/utils/modules/asyncCallWithTimeout";
 import { emitDeprecationWarning } from "@/llm/_utils.deprecationWarning";
 import { isLlmExeError } from "@/errors";
-import type { ErrorCategory } from "@/errors";
+import type { ErrorCategory, ErrorCodes } from "@/errors";
 
 // const doNotRetryErrorMessages: string[] = [];
 
@@ -22,6 +22,23 @@ const NON_RETRYABLE_CATEGORIES = new Set<ErrorCategory>([
   "configuration",
   "prompt",
   "auth",
+]);
+
+// Deterministic LlmExeError codes that live in an otherwise-mixed category
+// (llm.* and embedding.* also carry transient rate_limited/unavailable codes),
+// so the category short-circuit above can't reach them. A bad key, a 400, or an
+// unsupported input/dimensions request re-fails identically on retry. Typed as
+// Set<ErrorCodes> so a mistyped code is a compile error, not a silent miss.
+// (embedding.missing_provider / invalid_provider are intentionally absent — they
+// throw at createEmbedding() construction, before the wrapper exists, so they
+// never reach this predicate.)
+const NON_RETRYABLE_CODES = new Set<ErrorCodes>([
+  "llm.provider_auth_failed",
+  "llm.provider_invalid_request",
+  "embedding.provider_auth_failed",
+  "embedding.provider_invalid_request",
+  "embedding.unsupported_input",
+  "embedding.unsupported_dimensions",
 ]);
 
 export function apiRequestWrapper<T extends Record<string, any>, I>(
@@ -94,7 +111,8 @@ export function apiRequestWrapper<T extends Record<string, any>, I>(
             }
             if (
               isLlmExeError(_error) &&
-              NON_RETRYABLE_CATEGORIES.has(_error.category)
+              (NON_RETRYABLE_CATEGORIES.has(_error.category) ||
+                NON_RETRYABLE_CODES.has(_error.code))
             ) {
               return false;
             }


### PR DESCRIPTION
# Pull Request

## Description

Closes #726. Follow-up to #724, **stacked on its branch** (`fix/no-retry-deterministic-errors`) — retarget to `development` once #724 merges. The diff here is only the #726 commit.

#724 short-circuits `backOff` retries for deterministic **categories** (`configuration`, `prompt`, `auth`). Some deterministic failures live in the mixed `llm.*` / `embedding.*` categories (which also carry transient `rate_limited` / `unavailable` codes), so category granularity can't reach them and they still burn `numOfAttempts`. The initial research on #726 confirmed `embedding.unsupported_dimensions` retrying 3× today.

This adds a typed `NON_RETRYABLE_CODES = new Set<ErrorCodes>([...])` beside `NON_RETRYABLE_CATEGORIES` in `apiRequestWrapper` and ORs it into the retry predicate (short-circuit stays **before** `metrics.total_call_retry++`, so non-retryable failures don't inflate the retry counter):

- `llm.provider_auth_failed` / `llm.provider_invalid_request` (401/403, 400/422 re-thrown in `llm.call.ts`)
- `embedding.provider_auth_failed` / `embedding.provider_invalid_request` (re-thrown in `embedding.call.ts`)
- `embedding.unsupported_input` / `embedding.unsupported_dimensions` (thrown in `mapBody`, so no HTTP `retryable` signal exists for them — the explicit code Set is the only mechanism that reaches these)

`embedding.missing_provider` / `embedding.invalid_provider` from the issue are **intentionally omitted**: they throw at `createEmbedding()` construction, before `apiRequestWrapper` exists, so they never reach the predicate. No test can exercise them through the wrapper, so listing them would imply coverage that never runs.

Typed as `Set<ErrorCodes>` so a mistyped code is a compile error, not a silent miss (same discipline as #724's `Set<ErrorCategory>`).

## Testing

`src/utils/modules/requestWrapper.test.ts`, extending #724's unit suite (predicate-level, matching its established style):

- `it.each` over all 6 codes → asserts each is **not** retried (handler ran once, `total_call_retry === 0`). These fail on `development`/#724 without this change.
- Negative guard: `embedding.provider_rate_limited` (same `embedding` category, transient) **still** retries, proving the code Set doesn't over-block the mixed category.

Results: `npm test` → **196 suites / 2933 tests pass**. `npm run typecheck` clean (src). `eslint` clean on the changed files.

## Accessibility Checklist

- [x] n/a — backend-only change, no docs/UI/images/animation/error-copy surface touched.

## Reviewers

Follow-up to #724; review handled by the review agent.