### PR TITLE
test(anthropic): pin escalated-effort floor guard + document timeout caveat (#714)

### DIFF
--- a/docs/llm/anthropic.options.part.md
+++ b/docs/llm/anthropic.options.part.md
@@ -17,6 +17,8 @@
 >
 > **`effort`:** Accepts `minimal`/`low`/`medium`/`high` (silently ignored on models that do not support reasoning, e.g. Claude 3.x). For the adaptive generation (Opus 4.6 / 4.7 / 4.8 / 5, Sonnet 4.6 / 5, Fable 5) it sets `output_config.effort` and adaptive `thinking`; `high` escalates to `xhigh` on Opus 4.7 / 4.8, and in that escalated case, if you do not pass `maxTokens`, its default is raised from 4096 to 65536 so adaptive thinking is not truncated (an explicit `maxTokens` is always honored). For the 4.5 generation it sets extended-thinking `budget_tokens` and raises `max_tokens` above the budget.
 >
+> **Timeout on the escalated path:** the raised 65536 ceiling lets an `xhigh` run generate for much longer, and llm-exe does not stream, so the whole response must complete within `timeout` (default 30000ms). A long generation can exceed it, and a timeout is retried (default `numOfAttempts` 2), costing a second billed attempt. Raise `timeout` when using `effort: "high"` on Opus 4.7 / 4.8.
+>
 > Because `effort` enables thinking, and Anthropic disallows sampling parameters while thinking is active, llm-exe drops `temperature` and `topK`, and drops `topP` unless it is `>= 0.95`, whenever `effort` enables thinking — so the request stays valid.
 >
 > A forced `tool_choice` (`functionCall: "any"` or a named tool) is incompatible with **extended** thinking (the 4.5 `enabled` path); llm-exe throws a clear error rather than send a request the API rejects. Adaptive thinking (4.6+/5) permits forced tool use, so it is allowed.

--- a/docs/llm/bedrock/anthropic.md
+++ b/docs/llm/bedrock/anthropic.md
@@ -36,6 +36,8 @@ In addition to the [generic options](/llm/generic), the following options are av
 >
 > **`effort` and sampling params:** `effort` maps to `output_config.effort` and adaptive/extended `thinking`, identical to the direct provider, including the Opus 4.7 / 4.8 `high` -> `xhigh` escalation, which raises the default `max_tokens` to 65536 when you do not set it. `topP` is dropped for the models that 400 on sampling parameters (Opus 4.7, 4.8, and 5; Sonnet 5; Fable 5).
 >
+> **Timeout on the escalated path:** the raised 65536 ceiling can let an `xhigh` run exceed the default 30000ms `timeout` (llm-exe does not stream), and timeouts are retried (default `numOfAttempts` 2), costing a second billed attempt. Raise `timeout` when using `effort: "high"` on Opus 4.7 / 4.8.
+>
 > Because `effort` enables thinking, and Anthropic disallows sampling parameters while thinking is active, llm-exe drops `topP` below `0.95` whenever `effort` enables thinking (and drops `temperature` / `topK` on the direct provider, which maps them). Pass `topP >= 0.95` if you need it. This applies to the direct provider as well.
 >
 > **Forced `tool_choice`:** `functionCall: "any"` (or a named tool) is incompatible with extended thinking (the 4.5 `enabled` path) on both providers, and llm-exe throws a clear error for it. Note Bedrock additionally rejects a forced `tool_choice` with **adaptive** thinking — which the direct API accepts — so combining `effort` with `functionCall: "any"` on an adaptive model returns a 400 from Bedrock; use `functionCall: "auto"` there.

--- a/src/llm/config/anthropic/anthropic.test.ts
+++ b/src/llm/config/anthropic/anthropic.test.ts
@@ -153,9 +153,30 @@ describe("anthropic config", () => {
         expect(output.max_tokens).toBe(4096);
       });
 
-      it("never lowers a caller's already-larger maxTokens when escalating", () => {
+      it("honors a caller-set maxTokens above the floor when escalating", () => {
         const output: Record<string, any> = { max_tokens: 100000 };
-        effortTransform("high", stateWith("claude-opus-4-7", ["effort", "maxTokens"]), output);
+        const result = effortTransform(
+          "high",
+          stateWith("claude-opus-4-8", ["effort", "maxTokens"]),
+          output
+        );
+        expect(result).toBe("xhigh");
+        expect(output.max_tokens).toBe(100000);
+      });
+
+      it("does not lower an already-larger max_tokens when escalating without caller maxTokens provenance", () => {
+        // callerSetMaxTokens is false (only "effort" is provided), but max_tokens
+        // is already above the floor — e.g. a future config default, or a direct
+        // mapBody call. The floor must raise, never lower. Pins the
+        // `currentMax < ESCALATED_EFFORT_MIN_MAX_TOKENS` guard, which the config
+        // path can't reach (its default is always below 65536).
+        const output: Record<string, any> = { max_tokens: 100000 };
+        const result = effortTransform(
+          "high",
+          stateWith("claude-opus-4-8", ["effort"]),
+          output
+        );
+        expect(result).toBe("xhigh");
         expect(output.max_tokens).toBe(100000);
       });
 


### PR DESCRIPTION
# Pull Request

## Description

Closes #714 (items 1 and 2). Item 3 is split out to #738. Follow-up to #713 / #712.

**Item 1 — pin the escalated-effort `max_tokens` floor guard (test-only).** The test named "never lowers a caller's already-larger maxTokens when escalating" passed caller-set provenance (`["effort","maxTokens"]`), so it short-circuited on `!callerSetMaxTokens` and never reached the `currentMax < ESCALATED_EFFORT_MIN_MAX_TOKENS` guard it claimed to cover — and with `100000 > floor` it passed regardless of either sub-condition. Renamed it to describe what it exercises (a caller-set value above the floor is honored), and added a test with only `effort` in provenance and `max_tokens: 100000` that actually pins the guard: the floor must raise, never lower. `effort.ts` is unchanged (the clause preserves floor-never-lowers semantics against a future default bump above 65536).

**Item 2 — document the 65536 ceiling vs the 30s timeout (docs-only).** The raised ceiling on the `high` -> `xhigh` path lets a run generate well past the 30000ms default `timeout`; llm-exe does not stream, so the whole response must finish inside `timeout`, and a timeout is a plain `Error` that is retried (default `numOfAttempts` 2), costing a second billed attempt. Added a caveat to both the direct (`docs/llm/anthropic.options.part.md`) and Bedrock (`docs/llm/bedrock/anthropic.md`) effort notes.

## Testing

- **Mutation-verified the new guard test:** deleting the `currentMax < ESCALATED_EFFORT_MIN_MAX_TOKENS` sub-condition fails the new test only (max_tokens drops to 65536, expected 100000); the renamed caller-set test and the existing raise/short-circuit/fail-closed cases still pass. Reverted.
- `npm test` -> **198 suites / 3001 tests pass**.
- `npm run typecheck` clean (src). `eslint` clean on the changed test file.
- Docs are prose-only additions inside the existing `> [!NOTE]` blocks; no new em dashes.

## Accessibility Checklist

- [x] n/a — test + docs-prose change; no new images, interactive elements, form controls, animation, or color-dependent state. Heading hierarchy unchanged (additions are blockquote paragraphs inside existing note blocks).

## Reviewers

Follow-up to #713 / #714; review by the review agent.