### PR TITLE
docs(anthropic): point the maxTokens row at the escalation floor (#738)

### DIFF
--- a/docs/llm/anthropic.options.part.md
+++ b/docs/llm/anthropic.options.part.md
@@ -3,7 +3,7 @@
 | anthropicApiKey | string  | undefined         | API key for Anthropic. Optionally can be set using process.env.ANTHROPIC_API_KEY |
 | model           | string  | —                 | The model to use. Must be specified when using `anthropic.chat.v1`.              |
 | temperature     | number  | undefined         | Maps to temperature. See Anthropic Docs                                          |
-| maxTokens       | number  | 4096              | Maps to max_tokens. See Anthropic Docs                                           |
+| maxTokens       | number  | 4096              | Maps to max_tokens. Raised to 65536 when unset on the escalated effort path (Opus 4.7 / 4.8 high). See the effort note below. |
 | effort          | string  | undefined         | Maps to reasoning effort / thinking. See the effort note below.                  |
 | topP            | number  | undefined         | Maps to top_p. See Anthropic Docs                                                |
 | topK            | number  | undefined         | Maps to top_k. See Anthropic Docs                                                |

--- a/docs/llm/bedrock/anthropic.md
+++ b/docs/llm/bedrock/anthropic.md
@@ -24,7 +24,7 @@ In addition to the [generic options](/llm/generic), the following options are av
 | Option       | Type   | Default   | Description                                                                 |
 | ------------ | ------ | --------- | --------------------------------------------------------------------------- |
 | model        | string | —         | The Bedrock model id. Must be specified. See AWS Bedrock Docs               |
-| maxTokens    | number | 10000     | Maps to `max_tokens`. See Anthropic Docs                                    |
+| maxTokens    | number | 10000     | Maps to `max_tokens`. Raised to 65536 when unset on the escalated effort path (Opus 4.7 / 4.8 high). See the effort note below. |
 | topP         | number | undefined | Maps to `top_p`. Dropped for reject models, or `< 0.95` under `effort`.     |
 | effort       | string | undefined | Maps to `output_config.effort` + `thinking`. See Anthropic provider.        |
 | awsRegion    | string | undefined | AWS Region. Can be set via `AWS_REGION` environment variable                |


### PR DESCRIPTION
# Pull Request

## Description

Closes #738. Docs-only follow-up split out of #714 (item 3).

The `maxTokens` rows in the Anthropic options tables read as an unconditional default with no pointer to the escalation note, even though on the Opus 4.7 / 4.8 `high` -> `xhigh` path the default is raised to 65536 when the caller does not set `maxTokens`:

- `docs/llm/anthropic.options.part.md` (`4096`)
- `docs/llm/bedrock/anthropic.md` (`10000`)

Both `Description` cells now say the default is raised to 65536 on the escalated effort path and point at the effort note below (which already documents the mechanism). The `Default` cells stay as the base defaults. Scope is exactly the two table rows; no note prose changed.

Independent of #739 (that PR adds a timeout caveat to the effort *note*; this touches the *table rows* — disjoint hunks).

## Testing

Docs-only, no code paths affected.

- Both tables re-checked: row counts unchanged (13 direct, 9 Bedrock), pipes intact, each row on its own line.
- No em dashes in the added text.

## Accessibility Checklist

- [x] n/a — docs table-cell wording only; no images, interactive elements, form controls, headings, animation, or color-dependent state.

## Reviewers

Follow-up to #714 / #739; review by the review agent.