### PR TITLE
fix(request): land the #726 non-retryable codes on development (revives #731)

### DIFF
--- a/src/utils/modules/requestWrapper.test.ts
+++ b/src/utils/modules/requestWrapper.test.ts
@@ -244,4 +244,70 @@ describe("apiRequestWrapper", () => {
     expect(retryDecision).toBe(true);
   });
 
+  // #726 — deterministic codes inside otherwise-mixed categories (llm.*, embedding.*)
+  // must not be retried, even though the category short-circuit alone can't reach them.
+  it.each([
+    "llm.provider_auth_failed",
+    "llm.provider_invalid_request",
+    "embedding.provider_auth_failed",
+    "embedding.provider_invalid_request",
+    "embedding.unsupported_input",
+    "embedding.unsupported_dimensions",
+  ] as const)(
+    "does not retry deterministic code %s (#726)",
+    async (code) => {
+      const error = new LlmExeError(`deterministic ${code}`, {
+        code,
+        context: { operation: "test" },
+      });
+      asyncCallWithTimeoutMock.mockRejectedValue(error);
+      backOffMock.mockClear().mockImplementation(async (fn, options) => {
+        try {
+          return await fn();
+        } catch (err) {
+          const shouldRetry = options.retry(err, 1);
+          if (shouldRetry) {
+            return await fn();
+          } else {
+            throw err;
+          }
+        }
+      });
+
+      const apiRequest = setupAPIRequestWrapper();
+      await expect(apiRequest.call(mockMessages)).rejects.toThrow(
+        `deterministic ${code}`
+      );
+
+      const metrics = apiRequest.getMetadata().metrics as any;
+      expect(metrics.total_call_retry).toBe(0);
+      expect(metrics.total_call_error).toBe(1);
+      // handler ran exactly once — the deterministic error was not retried
+      expect(mockHandler).toHaveBeenCalledTimes(1);
+    }
+  );
+
+  it("still retries a transient LlmExeError in a mixed category (embedding.provider_rate_limited) (#726)", async () => {
+    const error = new LlmExeError("rate limited", {
+      code: "embedding.provider_rate_limited",
+      context: { operation: "test" },
+    });
+    asyncCallWithTimeoutMock.mockRejectedValue(error);
+    let retryDecision: boolean | undefined;
+    backOffMock.mockClear().mockImplementation(async (fn, options) => {
+      try {
+        return await fn();
+      } catch (err) {
+        retryDecision = options.retry(err, 1);
+        throw err;
+      }
+    });
+
+    const apiRequest = setupAPIRequestWrapper();
+    await expect(apiRequest.call(mockMessages)).rejects.toThrow("rate limited");
+    // transient code shares the embedding category — must NOT be short-circuited
+    expect(retryDecision).toBe(true);
+    expect((apiRequest.getMetadata().metrics as any).total_call_retry).toBe(1);
+  });
+
 });

--- a/src/utils/modules/requestWrapper.ts
+++ b/src/utils/modules/requestWrapper.ts
@@ -9,7 +9,7 @@ import { backOff } from "exponential-backoff";
 import { asyncCallWithTimeout } from "@/utils/modules/asyncCallWithTimeout";
 import { emitDeprecationWarning } from "@/llm/_utils.deprecationWarning";
 import { isLlmExeError } from "@/errors";
-import type { ErrorCategory } from "@/errors";
+import type { ErrorCategory, ErrorCodes } from "@/errors";
 
 // const doNotRetryErrorMessages: string[] = [];
 
@@ -22,6 +22,23 @@ const NON_RETRYABLE_CATEGORIES = new Set<ErrorCategory>([
   "configuration",
   "prompt",
   "auth",
+]);
+
+// Deterministic LlmExeError codes that live in an otherwise-mixed category
+// (llm.* and embedding.* also carry transient rate_limited/unavailable codes),
+// so the category short-circuit above can't reach them. A bad key, a 400, or an
+// unsupported input/dimensions request re-fails identically on retry. Typed as
+// Set<ErrorCodes> so a mistyped code is a compile error, not a silent miss.
+// (embedding.missing_provider / invalid_provider are intentionally absent — they
+// throw at createEmbedding() construction, before the wrapper exists, so they
+// never reach this predicate.)
+const NON_RETRYABLE_CODES = new Set<ErrorCodes>([
+  "llm.provider_auth_failed",
+  "llm.provider_invalid_request",
+  "embedding.provider_auth_failed",
+  "embedding.provider_invalid_request",
+  "embedding.unsupported_input",
+  "embedding.unsupported_dimensions",
 ]);
 
 export function apiRequestWrapper<T extends Record<string, any>, I>(
@@ -94,7 +111,8 @@ export function apiRequestWrapper<T extends Record<string, any>, I>(
             }
             if (
               isLlmExeError(_error) &&
-              NON_RETRYABLE_CATEGORIES.has(_error.category)
+              (NON_RETRYABLE_CATEGORIES.has(_error.category) ||
+                NON_RETRYABLE_CODES.has(_error.code))
             ) {
               return false;
             }


### PR DESCRIPTION
# Pull Request

## Description

Re-lands #731 (closes #726), which was approved and merged but **never reached `development`**. It was stacked on #724's branch, and the merge order went: #724 -> `development` at 16:18:30Z on 2026-08-09, then #731 -> `fix/no-retry-deterministic-errors` ten seconds later. The commit stranded on the feature branch; `development` has no `NON_RETRYABLE_CODES` today (discovered while auditing the docs PRs: #746 documents `llm.provider_auth_failed` as "still retried", which is accurate against current `development` but not the approved #731 behavior).

This is a clean cherry-pick of 96dba62 onto `development`: a typed `NON_RETRYABLE_CODES` set beside #724's category set, OR'd into the retry predicate, covering the six deterministic codes in mixed categories (`llm.provider_auth_failed`, `llm.provider_invalid_request`, `embedding.provider_auth_failed`, `embedding.provider_invalid_request`, `embedding.unsupported_input`, `embedding.unsupported_dimensions`).

Note for the docs queue: once this merges, the "still retried" note in #746's `docs/misc/errors.md` needs its one-sentence update (flagged there).

## Testing

- `npm test` -> 198 suites / 3041 tests pass (includes the 6-code `it.each` + the `embedding.provider_rate_limited` negative guard from #731)
- `npm run typecheck` clean

## Accessibility Checklist

- [x] n/a — backend retry logic + tests only.

## Reviewers

Review previously done on #731 (approved); this is the same commit landing on the right base.