### PR TITLE
feat: support content blocks (images) in tool/function results (part of #757)

### DIFF
--- a/src/interfaces/chat.ts
+++ b/src/interfaces/chat.ts
@@ -57,7 +57,7 @@ export interface IChatUserMessage extends IChatMessageBase {
 export interface IChatFunctionMessage extends IChatMessageBase {
   id?: string;
   role: Extract<IChatMessageRole, "function">;
-  content: string;
+  content: string | IChatMessageContentDetailed[];
   name: string;
 }
 

--- a/src/llm/config/_utils/imageContent.ts
+++ b/src/llm/config/_utils/imageContent.ts
@@ -42,9 +42,13 @@ export function isImageUrlContentBlock(
  * content blocks must not capture those arrays too, or a working call turns
  * into a provider 400 (Anthropic) or a thrown error (Gemini).
  *
- * `IChatMessageContentDetailed` requires `type: string`, so requiring every
- * entry to carry one matches the declared type exactly. Empty arrays keep the
- * arbitrary-JSON path, which is what they did before content blocks existed.
+ * Entries must be *recognized* blocks, not merely objects carrying a `type`.
+ * `type` is one of the most common discriminators in JSON tool output
+ * (`{type:"flight"}`, `{type:"hotel"}`), so keying on it alone would still
+ * divert ordinary payloads. Matching the two shapes
+ * `IChatMessageContentDetailed` actually models — a `text` block or an image
+ * block — keeps everything else on the arbitrary-JSON path. Empty arrays stay
+ * there too, which is what they did before content blocks existed.
  */
 export function isContentBlockArray(
   content: unknown,
@@ -56,7 +60,9 @@ export function isContentBlockArray(
       (block) =>
         typeof block === "object" &&
         block !== null &&
-        typeof (block as Record<string, any>).type === "string",
+        typeof (block as Record<string, any>).type === "string" &&
+        (typeof (block as Record<string, any>).text === "string" ||
+          isImageUrlContentBlock(block)),
     )
   );
 }

--- a/src/llm/config/_utils/imageContent.ts
+++ b/src/llm/config/_utils/imageContent.ts
@@ -1,5 +1,8 @@
 import { LlmExeError } from "@/errors";
-import { IChatMessageContentImageUrl } from "@/interfaces";
+import {
+  IChatMessageContentDetailed,
+  IChatMessageContentImageUrl,
+} from "@/interfaces";
 
 export type ParsedImageUrl =
   | { kind: "base64"; mediaType: string; data: string }
@@ -27,6 +30,34 @@ export function isImageUrlContentBlock(
     typeof imageUrl === "object" &&
     imageUrl !== null &&
     typeof imageUrl.url === "string"
+  );
+}
+
+/**
+ * Distinguishes a content-block array from an arbitrary JSON array.
+ *
+ * Tool results have always accepted arbitrary JSON — an array of plain objects
+ * is a deliberate, tested path (`maybeStringifyJSON` for Anthropic, a verbatim
+ * Struct value for Gemini). Widening `IChatFunctionMessage.content` to allow
+ * content blocks must not capture those arrays too, or a working call turns
+ * into a provider 400 (Anthropic) or a thrown error (Gemini).
+ *
+ * `IChatMessageContentDetailed` requires `type: string`, so requiring every
+ * entry to carry one matches the declared type exactly. Empty arrays keep the
+ * arbitrary-JSON path, which is what they did before content blocks existed.
+ */
+export function isContentBlockArray(
+  content: unknown,
+): content is IChatMessageContentDetailed[] {
+  return (
+    Array.isArray(content) &&
+    content.length > 0 &&
+    content.every(
+      (block) =>
+        typeof block === "object" &&
+        block !== null &&
+        typeof (block as Record<string, any>).type === "string",
+    )
   );
 }
 

--- a/src/llm/config/anthropic/promptSanitizeMessageCallback.test.ts
+++ b/src/llm/config/anthropic/promptSanitizeMessageCallback.test.ts
@@ -134,6 +134,26 @@ describe("anthropicPromptMessageCallback", () => {
       expect(result.content[0].content).toBe('[{"title":"a"},{"title":"b"}]');
     });
 
+    it("stringifies a JSON array whose entries carry a discriminator `type`", () => {
+      // `type` is a very common discriminator in real tool output. These are
+      // not content blocks (no text / image_url), so they must stay on the
+      // stringify path — passing them through as tool_result blocks is a 400
+      // from the API for an unknown block type.
+      const message: IChatMessage = {
+        role: "function",
+        id: "call-typed-json",
+        name: "search",
+        content: [
+          { type: "flight", id: 1 },
+          { type: "hotel", id: 2 },
+        ] as any,
+      };
+
+      expect(anthropicPromptMessageCallback(message).content[0].content).toBe(
+        '[{"type":"flight","id":1},{"type":"hotel","id":2}]'
+      );
+    });
+
     it("keeps an empty array on the stringify path", () => {
       const message: IChatMessage = {
         role: "function",

--- a/src/llm/config/anthropic/promptSanitizeMessageCallback.test.ts
+++ b/src/llm/config/anthropic/promptSanitizeMessageCallback.test.ts
@@ -59,6 +59,129 @@ describe("anthropicPromptMessageCallback", () => {
       });
     });
 
+    it("passes content blocks through as a native tool_result array", () => {
+      const message: IChatMessage = {
+        role: "function",
+        id: "test-id-123",
+        name: "screenshot",
+        content: [
+          { type: "text", text: "Here is the screenshot" },
+          {
+            type: "image_url",
+            image_url: { url: "data:image/png;base64,iVBORw0KGgo=" },
+          },
+        ],
+      };
+
+      const result = anthropicPromptMessageCallback(message);
+
+      expect(result).toEqual({
+        role: "user",
+        content: [
+          {
+            type: "tool_result",
+            tool_use_id: "test-id-123",
+            content: [
+              { type: "text", text: "Here is the screenshot" },
+              {
+                type: "image",
+                source: {
+                  type: "base64",
+                  media_type: "image/png",
+                  data: "iVBORw0KGgo=",
+                },
+              },
+            ],
+          },
+        ],
+      });
+    });
+
+    it("converts image url sources inside tool results when allowed", () => {
+      const message: IChatMessage = {
+        role: "function",
+        id: "test-id-124",
+        name: "screenshot",
+        content: [
+          {
+            type: "image_url",
+            image_url: { url: "https://example.com/a.png" },
+          },
+        ],
+      };
+
+      const result = anthropicPromptMessageCallback(message);
+
+      expect(result.content[0].content).toEqual([
+        { type: "image", source: { type: "url", url: "https://example.com/a.png" } },
+      ]);
+    });
+
+    it("still stringifies an arbitrary JSON array tool result (not a content-block array)", () => {
+      // Regression: an array of plain objects is a long-standing tool-result
+      // path (maybeStringifyJSON has explicit array coverage). Widening the
+      // type for content blocks must not divert it into tool_result.content,
+      // where blocks without a `type` are a 400 from the API.
+      const message: IChatMessage = {
+        role: "function",
+        id: "call-json-array",
+        name: "search",
+        content: [{ title: "a" }, { title: "b" }] as any,
+      };
+
+      const result = anthropicPromptMessageCallback(message);
+
+      expect(result.content[0].content).toBe('[{"title":"a"},{"title":"b"}]');
+    });
+
+    it("keeps an empty array on the stringify path", () => {
+      const message: IChatMessage = {
+        role: "function",
+        id: "call-empty-array",
+        name: "search",
+        content: [] as any,
+      };
+
+      expect(anthropicPromptMessageCallback(message).content[0].content).toBe(
+        "[]"
+      );
+    });
+
+    it("stringifies a mixed array where only some entries are content blocks", () => {
+      // Not a content-block array: one entry has no `type`, so the whole thing
+      // is arbitrary JSON and must not be sent as tool_result blocks.
+      const message: IChatMessage = {
+        role: "function",
+        id: "call-mixed",
+        name: "search",
+        content: [{ type: "text", text: "a" }, { title: "b" }] as any,
+      };
+
+      expect(anthropicPromptMessageCallback(message).content[0].content).toBe(
+        '[{"type":"text","text":"a"},{"title":"b"}]'
+      );
+    });
+
+    it("throws when a tool result image url is not allowed by the provider", () => {
+      const message: IChatMessage = {
+        role: "function",
+        id: "test-id-125",
+        name: "screenshot",
+        content: [
+          {
+            type: "image_url",
+            image_url: { url: "https://example.com/a.png" },
+          },
+        ],
+      };
+
+      expect(() =>
+        anthropicPromptMessageCallback(message, {
+          allowImageUrlSources: false,
+        })
+      ).toThrow("Image URLs are not supported by this provider");
+    });
+
     it("removes id field when role is function", () => {
       const message: IChatMessage = {
         role: "function",

--- a/src/llm/config/anthropic/promptSanitizeMessageCallback.ts
+++ b/src/llm/config/anthropic/promptSanitizeMessageCallback.ts
@@ -26,6 +26,12 @@ export function anthropicPromptMessageCallback(
   /// TODO: Type this properly, its an Anthropic message
   let message: Record<string, any> = { ..._message };
 
+  // Classify the caller's input before the conversion below rewrites image
+  // blocks into Anthropic's `{ type: "image", source }` shape — that shape is
+  // no longer recognizable as caller-supplied content, so the tool_result
+  // branch has to decide based on what actually came in.
+  const contentIsBlocks = isContentBlockArray(_message.content);
+
   if (Array.isArray(message.content)) {
     message.content = message.content.map((block: any) => {
       if (!isImageUrlContentBlock(block)) {
@@ -75,7 +81,7 @@ export function anthropicPromptMessageCallback(
       {
         type: "tool_result",
         tool_use_id: message.id,
-        content: isContentBlockArray(message.content)
+        content: contentIsBlocks
           ? message.content
           : maybeStringifyJSON(message.content),
       },

--- a/src/llm/config/anthropic/promptSanitizeMessageCallback.ts
+++ b/src/llm/config/anthropic/promptSanitizeMessageCallback.ts
@@ -2,6 +2,7 @@ import { IChatMessage } from "@/interfaces";
 import { LlmExeError } from "@/errors";
 import { maybeParseJSON, maybeStringifyJSON } from "@/utils";
 import {
+  isContentBlockArray,
   isImageUrlContentBlock,
   parseImageUrl,
 } from "../_utils/imageContent";
@@ -66,11 +67,17 @@ export function anthropicPromptMessageCallback(
 
   if (message.role === "function") {
     message.role = "user";
+    // A content-block array has already been converted to Anthropic block
+    // shapes above; pass it through as the tool_result content array so images
+    // stay native. Everything else — including an arbitrary JSON array, which
+    // is a long-standing tool-result path — still gets stringified.
     message.content = [
       {
         type: "tool_result",
         tool_use_id: message.id,
-        content: maybeStringifyJSON(message.content),
+        content: isContentBlockArray(message.content)
+          ? message.content
+          : maybeStringifyJSON(message.content),
       },
     ];
 

--- a/src/llm/config/google/promptSanitizeMessageCallback.test.ts
+++ b/src/llm/config/google/promptSanitizeMessageCallback.test.ts
@@ -126,6 +126,109 @@ describe("googleGeminiPromptMessageCallback", () => {
       });
       expect(result).not.toHaveProperty("id");
     });
+
+    it("flattens a text-only block array into the response result", () => {
+      const message: IChatMessage = {
+        role: "function",
+        name: "testFunction",
+        content: [
+          { type: "text", text: "line one" },
+          { type: "text", text: "line two" },
+        ],
+      };
+
+      const result = googleGeminiPromptMessageCallback(message);
+
+      expect(result).toEqual({
+        role: "user",
+        parts: [
+          {
+            functionResponse: {
+              name: "testFunction",
+              response: {
+                result: "line one\nline two",
+              },
+            },
+          },
+        ],
+      });
+    });
+
+    it("passes an arbitrary JSON array tool result into the Struct verbatim", () => {
+      // Regression: functionResponse.response is an arbitrary Struct, so a JSON
+      // array is valid (and idiomatic) structured tool output. Widening the
+      // type for content blocks must not turn this into a thrown error.
+      const message: IChatMessage = {
+        role: "function",
+        name: "search",
+        content: [{ title: "a" }, { title: "b" }] as any,
+      };
+
+      const result = googleGeminiPromptMessageCallback(message);
+
+      expect(result.parts[0].functionResponse.response.result).toEqual([
+        { title: "a" },
+        { title: "b" },
+      ]);
+    });
+
+    it("passes an empty array into the Struct verbatim", () => {
+      const message: IChatMessage = {
+        role: "function",
+        name: "search",
+        content: [] as any,
+      };
+
+      const result = googleGeminiPromptMessageCallback(message);
+
+      expect(result.parts[0].functionResponse.response.result).toEqual([]);
+    });
+
+    it("passes a mixed array through verbatim rather than flattening it", () => {
+      // One entry has no `type`, so this is arbitrary JSON, not content blocks.
+      const message: IChatMessage = {
+        role: "function",
+        name: "search",
+        content: [{ type: "text", text: "a" }, { title: "b" }] as any,
+      };
+
+      const result = googleGeminiPromptMessageCallback(message);
+
+      expect(result.parts[0].functionResponse.response.result).toEqual([
+        { type: "text", text: "a" },
+        { title: "b" },
+      ]);
+    });
+
+    it("throws when a tool result carries an image block", () => {
+      const message: IChatMessage = {
+        role: "function",
+        name: "testFunction",
+        content: [
+          { type: "text", text: "here it is" },
+          {
+            type: "image_url",
+            image_url: { url: "data:image/png;base64,iVBORw0KGgo=" },
+          },
+        ],
+      };
+
+      expect(() => googleGeminiPromptMessageCallback(message)).toThrow(
+        "Image content is not supported in tool results by Gemini"
+      );
+    });
+
+    it("throws on an unrecognized block inside a tool result", () => {
+      const message: IChatMessage = {
+        role: "function",
+        name: "testFunction",
+        content: [{ type: "audio" } as any],
+      };
+
+      expect(() => googleGeminiPromptMessageCallback(message)).toThrow(
+        "Unsupported content block in tool result"
+      );
+    });
   });
 
   describe("function_call handling", () => {

--- a/src/llm/config/google/promptSanitizeMessageCallback.test.ts
+++ b/src/llm/config/google/promptSanitizeMessageCallback.test.ts
@@ -172,6 +172,26 @@ describe("googleGeminiPromptMessageCallback", () => {
       ]);
     });
 
+    it("passes a JSON array whose entries carry a discriminator `type` into the Struct verbatim", () => {
+      // Not content blocks (no text / image_url), so this stays arbitrary JSON
+      // and must not be flattened or thrown on.
+      const message: IChatMessage = {
+        role: "function",
+        name: "search",
+        content: [
+          { type: "flight", id: 1 },
+          { type: "hotel", id: 2 },
+        ] as any,
+      };
+
+      const result = googleGeminiPromptMessageCallback(message);
+
+      expect(result.parts[0].functionResponse.response.result).toEqual([
+        { type: "flight", id: 1 },
+        { type: "hotel", id: 2 },
+      ]);
+    });
+
     it("passes an empty array into the Struct verbatim", () => {
       const message: IChatMessage = {
         role: "function",
@@ -218,16 +238,21 @@ describe("googleGeminiPromptMessageCallback", () => {
       );
     });
 
-    it("throws on an unrecognized block inside a tool result", () => {
+    it("treats an unrecognized typed block as arbitrary JSON, not a content block", () => {
+      // {type:"audio"} is not a shape IChatMessageContentDetailed models, so it
+      // stays on the long-standing arbitrary-JSON path and lands in the Struct
+      // verbatim rather than throwing.
       const message: IChatMessage = {
         role: "function",
         name: "testFunction",
         content: [{ type: "audio" } as any],
       };
 
-      expect(() => googleGeminiPromptMessageCallback(message)).toThrow(
-        "Unsupported content block in tool result"
-      );
+      const result = googleGeminiPromptMessageCallback(message);
+
+      expect(result.parts[0].functionResponse.response.result).toEqual([
+        { type: "audio" },
+      ]);
     });
   });
 

--- a/src/llm/config/google/promptSanitizeMessageCallback.ts
+++ b/src/llm/config/google/promptSanitizeMessageCallback.ts
@@ -2,6 +2,7 @@ import { IChatMessage } from "@/types";
 import { LlmExeError } from "@/errors";
 import { maybeParseJSON } from "@/utils";
 import {
+  isContentBlockArray,
   isImageUrlContentBlock,
   parseImageUrl,
 } from "../_utils/imageContent";
@@ -46,6 +47,57 @@ function googleGeminiContentBlockToPart(block: any) {
   return block;
 }
 
+/**
+ * `functionResponse.response` is a Struct — it has no representation for an
+ * image part, and Gemini accepts a block array dropped in verbatim, so the
+ * base64 gets billed as text and the image is never seen. Text-only arrays
+ * flatten to a string (what the non-function branch does for every other
+ * role); image blocks throw rather than fail silently.
+ *
+ * Only content-block arrays are rewritten. An arbitrary JSON array is valid,
+ * idiomatic structured tool output for a Struct, so it keeps landing verbatim.
+ */
+function googleGeminiFunctionResponseResult(content: any) {
+  if (!isContentBlockArray(content)) {
+    return content;
+  }
+
+  return content
+    .map((block: any) => {
+      if (isImageUrlContentBlock(block)) {
+        throw new LlmExeError(
+          "Image content is not supported in tool results by Gemini",
+          {
+            code: "prompt.invalid_messages",
+            context: {
+              operation: "googleGeminiPromptMessageCallback",
+              provider: "google.chat",
+              received: "a tool result containing an image content block",
+              expected: "text-only tool result content",
+              resolution:
+                "functionResponse.response only carries structured text. Return text from the tool and send the image as a separate user message.",
+            },
+          }
+        );
+      }
+      if (typeof block?.text !== "string") {
+        throw new LlmExeError("Unsupported content block in tool result", {
+          code: "prompt.invalid_messages",
+          context: {
+            operation: "googleGeminiPromptMessageCallback",
+            provider: "google.chat",
+            received: block,
+            expected: "text content blocks",
+            resolution:
+              "Tool results sent to Gemini may only contain text content blocks.",
+          },
+        });
+      }
+      return block.text;
+    })
+    .join("\n");
+}
+
 export function googleGeminiPromptMessageCallback(_message: IChatMessage) {
   /// TODO: Type this properly, its a Gemini message
   let message: Record<string, any> = { ..._message };
@@ -81,7 +133,7 @@ export function googleGeminiPromptMessageCallback(_message: IChatMessage) {
       functionResponse: {
         name: message.name,
         response: {
-          result: message.content,
+          result: googleGeminiFunctionResponseResult(message.content),
         },
       },
     });

--- a/src/llm/config/google/promptSanitizeMessageCallback.ts
+++ b/src/llm/config/google/promptSanitizeMessageCallback.ts
@@ -80,19 +80,8 @@ function googleGeminiFunctionResponseResult(content: any) {
           }
         );
       }
-      if (typeof block?.text !== "string") {
-        throw new LlmExeError("Unsupported content block in tool result", {
-          code: "prompt.invalid_messages",
-          context: {
-            operation: "googleGeminiPromptMessageCallback",
-            provider: "google.chat",
-            received: block,
-            expected: "text content blocks",
-            resolution:
-              "Tool results sent to Gemini may only contain text content blocks.",
-          },
-        });
-      }
+      // isContentBlockArray admits only text or image blocks, and images throw
+      // above, so anything reaching here is a text block.
       return block.text;
     })
     .join("\n");

--- a/src/llm/config/openai/promptSanitizeMessageCallback.test.ts
+++ b/src/llm/config/openai/promptSanitizeMessageCallback.test.ts
@@ -394,6 +394,41 @@ describe("openaiPromptMessageCallback", () => {
       });
     });
 
+    it("throws when a tool result carries an image block", () => {
+      const message = {
+        role: "function",
+        id: "call_1",
+        name: "get_snapshot",
+        content: [
+          { type: "text", text: "here it is" },
+          {
+            type: "image_url",
+            image_url: { url: "data:image/png;base64,iVBORw0KGgo=" },
+          },
+        ],
+      };
+
+      expect(() => openaiPromptMessageCallback(message)).toThrow(
+        "Image content is not supported in tool results by this provider"
+      );
+    });
+
+    it("passes a text-only tool result block array through", () => {
+      const message = {
+        role: "function",
+        id: "call_1",
+        content: [{ type: "text", text: "72 and sunny" }],
+      };
+
+      const result = openaiPromptMessageCallback(message);
+
+      expect(result).toEqual({
+        role: "tool",
+        tool_call_id: "call_1",
+        content: [{ type: "text", text: "72 and sunny" }],
+      });
+    });
+
     it("leaves non-image blocks in arrays untouched", () => {
       const message = {
         role: "user",

--- a/src/llm/config/openai/promptSanitizeMessageCallback.ts
+++ b/src/llm/config/openai/promptSanitizeMessageCallback.ts
@@ -1,3 +1,4 @@
+import { LlmExeError } from "@/errors";
 import { isImageUrlContentBlock } from "../_utils/imageContent";
 
 export function openaiPromptMessageCallback(_message: any) {
@@ -14,6 +15,30 @@ export function openaiPromptMessageCallback(_message: any) {
   }
 
   if (message.role === "function") {
+    // Chat Completions `tool` messages take text only — an image block here is
+    // accepted by the type but rejected by the API, so fail in llm-exe with a
+    // resolution instead of surfacing a provider 400. Text-only block arrays
+    // are fine and pass through.
+    if (
+      Array.isArray(message.content) &&
+      message.content.some(isImageUrlContentBlock)
+    ) {
+      throw new LlmExeError(
+        "Image content is not supported in tool results by this provider",
+        {
+          code: "prompt.invalid_messages",
+          context: {
+            operation: "openaiPromptMessageCallback",
+            provider: "openai-compatible",
+            received: "a tool result containing an image content block",
+            expected: "text-only tool result content",
+            resolution:
+              "Return text from the tool and send the image as a separate user message, or use an Anthropic model, which accepts images inside tool results.",
+          },
+        }
+      );
+    }
+
     message.role = "tool";
     message.tool_call_id = message.id;
     delete message.id;

--- a/src/llm/config/promptSanitizeContract.test.ts
+++ b/src/llm/config/promptSanitizeContract.test.ts
@@ -101,6 +101,21 @@ const FIXTURES: Fixture[] = [
       },
     ],
   },
+  {
+    name: "image tool result",
+    messages: () => [
+      { role: "user", content: "what does the camera see?" },
+      {
+        role: "function",
+        id: "call_1",
+        name: "get_snapshot",
+        content: [
+          { type: "text", text: "here is the snapshot" },
+          { type: "image_url", image_url: { url: PNG_DATA_URI } },
+        ],
+      },
+    ],
+  },
 ];
 
 /** what one fixture becomes for one provider */
@@ -183,6 +198,10 @@ const openaiExpectations: Record<string, Expectation> = {
         tool_call_id: "call_1",
       },
     ],
+  },
+  // Chat Completions `tool` messages are text-only
+  "image tool result": {
+    throws: "Image content is not supported in tool results by this provider",
   },
 };
 
@@ -267,6 +286,33 @@ function anthropicExpectations(options: {
         },
       ],
     },
+    // anthropic is the one provider that takes images natively inside a
+    // tool_result, so the blocks stay blocks
+    "image tool result": {
+      prompt: [
+        { role: "user", content: "what does the camera see?" },
+        {
+          role: "user",
+          content: [
+            {
+              type: "tool_result",
+              tool_use_id: "call_1",
+              content: [
+                { type: "text", text: "here is the snapshot" },
+                {
+                  type: "image",
+                  source: {
+                    type: "base64",
+                    media_type: "image/png",
+                    data: PNG_BASE64,
+                  },
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    },
   };
 }
 
@@ -329,6 +375,10 @@ const googleExpectations: Record<string, Expectation> = {
       },
     ],
   },
+  // functionResponse.response is a text-only Struct
+  "image tool result": {
+    throws: "Image content is not supported in tool results by Gemini",
+  },
 };
 
 const ollamaExpectations: Record<string, Expectation> = {
@@ -389,6 +439,21 @@ const ollamaExpectations: Record<string, Expectation> = {
       },
     ],
   },
+  // `ollamaPromptSanitize` is role-agnostic, so a tool result with array
+  // content splits into text + `images` like any other message. Whether
+  // ollama honors `images` on a tool-role message is the open part of #706.
+  "image tool result": {
+    prompt: [
+      { role: "user", content: "what does the camera see?" },
+      {
+        role: "function",
+        id: "call_1",
+        name: "get_snapshot",
+        content: "here is the snapshot",
+        images: [PNG_BASE64],
+      },
+    ],
+  },
 };
 
 /**
@@ -409,6 +474,7 @@ const metaExpectations: Record<string, Expectation> = {
   },
   "assistant tool call": { prompt: "\nUser: weather?\nAssistant: \n" },
   "tool result": { prompt: "\nUser: weather?\n" },
+  "image tool result": { throws: "Image content is not supported" },
 };
 
 /** the mock provider has no prompt transform — messages pass through verbatim */

--- a/src/prompt/chat.test.ts
+++ b/src/prompt/chat.test.ts
@@ -823,4 +823,75 @@ describe("llm-exe:prompt/ChatPrompt", () => {
       { content: null, role: "assistant" },
     ]);
   });
+  describe("function messages with content blocks", () => {
+    const imageBlock = {
+      type: "image_url",
+      image_url: { url: "data:image/png;base64,iVBORw0KGgo=" },
+    };
+
+    it("templates text blocks and passes image blocks through (sync)", () => {
+      const prompt = new ChatPrompt<{ label: string }>("System");
+      prompt.addFunctionMessage(
+        [{ type: "text", text: "Screenshot of {{label}}" }, imageBlock],
+        "screenshot",
+        "call_1"
+      );
+      const result = prompt.format({ label: "the homepage" });
+      expect(result[1]).toEqual({
+        role: "function",
+        name: "screenshot",
+        id: "call_1",
+        content: [
+          { type: "text", text: "Screenshot of the homepage" },
+          imageBlock,
+        ],
+      });
+    });
+
+    it("templates text blocks and passes image blocks through (async)", async () => {
+      const prompt = new ChatPrompt<{ label: string }>("System");
+      prompt.addFunctionMessage(
+        [{ type: "text", text: "Screenshot of {{label}}" }, imageBlock],
+        "screenshot",
+        "call_1"
+      );
+      const result = await prompt.formatAsync({ label: "the homepage" });
+      expect(result[1]).toEqual({
+        role: "function",
+        name: "screenshot",
+        id: "call_1",
+        content: [
+          { type: "text", text: "Screenshot of the homepage" },
+          imageBlock,
+        ],
+      });
+    });
+
+    it("keeps string function content behavior unchanged", () => {
+      const prompt = new ChatPrompt<{ label: string }>("System");
+      prompt.addFunctionMessage("Result for {{label}}", "lookup", "call_2");
+      expect(prompt.format({ label: "x" })[1]).toEqual({
+        role: "function",
+        name: "lookup",
+        id: "call_2",
+        content: "Result for x",
+      });
+    });
+
+    it("round trips block content through addFromHistory", () => {
+      const prompt = new ChatPrompt("System");
+      prompt.addFromHistory([
+        {
+          role: "function",
+          name: "screenshot",
+          id: "call_3",
+          content: [{ type: "text", text: "done" }, imageBlock],
+        },
+      ]);
+      expect(prompt.format({})[1].content).toEqual([
+        { type: "text", text: "done" },
+        imageBlock,
+      ]);
+    });
+  });
 });

--- a/src/prompt/chat.ts
+++ b/src/prompt/chat.ts
@@ -77,7 +77,7 @@ export class ChatPrompt<I extends Record<string, any>> extends BasePrompt<I> {
     name?: string
   ): ChatPrompt<I>;
   addToPrompt(
-    content: string,
+    content: string | IChatMessageContentDetailed[],
     role: Extract<IChatMessageRole, "function">,
     name: string
   ): ChatPrompt<I>;
@@ -87,7 +87,7 @@ export class ChatPrompt<I extends Record<string, any>> extends BasePrompt<I> {
     name: string
   ): ChatPrompt<I>;
   addToPrompt(
-    content: string,
+    content: string | IChatMessageContentDetailed[],
     role: IChatMessageRole,
     name?: string,
     id?: string
@@ -95,13 +95,13 @@ export class ChatPrompt<I extends Record<string, any>> extends BasePrompt<I> {
     if (content) {
       switch (role) {
         case "system":
-          this.addSystemMessage(content);
+          this.addSystemMessage(content as string);
           break;
         case "user":
           this.addUserMessage(content, name);
           break;
         case "assistant":
-          this.addAssistantMessage(content);
+          this.addAssistantMessage(content as string);
           break;
         case "function":
           assert(name, "Function message requires name");
@@ -109,7 +109,11 @@ export class ChatPrompt<I extends Record<string, any>> extends BasePrompt<I> {
           break;
         case "function_call":
           assert(name, "Function message requires name");
-          this.addFunctionCallMessage({ name: name, arguments: content, id });
+          this.addFunctionCallMessage({
+            name: name,
+            arguments: content as string,
+            id,
+          });
           break;
       }
     }
@@ -156,7 +160,7 @@ export class ChatPrompt<I extends Record<string, any>> extends BasePrompt<I> {
    * @return ChatPrompt so it can be chained.
    */
   addFunctionMessage(
-    content: string,
+    content: string | IChatMessageContentDetailed[],
     name: string,
     id?: string
   ): ChatPrompt<I> {
@@ -380,14 +384,27 @@ export class ChatPrompt<I extends Record<string, any>> extends BasePrompt<I> {
           }
         }
       } else if (message.role === "function") {
-        messagesOut.push(
-          Object.assign({}, message, {
-            content: this.replaceTemplateString(message.content, replacements, {
+        // Template `text` blocks and pass everything else (images) through
+        // untouched. Unlike the user-message branch below, prompt filters are
+        // not run here and blocks keep their original shape — function content
+        // has never been filtered, so this preserves that.
+        const content = Array.isArray(message.content)
+          ? message.content.map((m) =>
+              m.text
+                ? {
+                    ...m,
+                    text: this.replaceTemplateString(m.text, replacements, {
+                      partials: this.partials,
+                      helpers: this.helpers,
+                    }),
+                  }
+                : m
+            )
+          : this.replaceTemplateString(message.content, replacements, {
               partials: this.partials,
               helpers: this.helpers,
-            }),
-          })
-        );
+            });
+        messagesOut.push(Object.assign({}, message, { content }));
       } else {
         if (safeToParseTemplate.includes(message.role)) {
           if (Array.isArray(message.content)) {
@@ -564,18 +581,38 @@ export class ChatPrompt<I extends Record<string, any>> extends BasePrompt<I> {
           }
         }
       } else if (message.role === "function") {
-        messagesOut.push(
-          Object.assign({}, message, {
-            content: await this.replaceTemplateStringAsync(
-              message.content,
-              replacements,
-              {
-                partials: this.partials,
-                helpers: this.helpers,
-              }
-            ),
-          })
-        );
+        let content: string | IChatMessageContentDetailed[];
+        if (Array.isArray(message.content)) {
+          const blocks: IChatMessageContentDetailed[] = [];
+          for (const m of message.content) {
+            blocks.push(
+              m.text
+                ? {
+                    ...m,
+                    text: await this.replaceTemplateStringAsync(
+                      m.text,
+                      replacements,
+                      {
+                        partials: this.partials,
+                        helpers: this.helpers,
+                      }
+                    ),
+                  }
+                : m
+            );
+          }
+          content = blocks;
+        } else {
+          content = await this.replaceTemplateStringAsync(
+            message.content,
+            replacements,
+            {
+              partials: this.partials,
+              helpers: this.helpers,
+            }
+          );
+        }
+        messagesOut.push(Object.assign({}, message, { content }));
       } else {
         if (safeToParseTemplate.includes(message.role)) {
           if (Array.isArray(message.content)) {

--- a/src/state/dialogue.test.ts
+++ b/src/state/dialogue.test.ts
@@ -556,6 +556,22 @@ describe("llm-exe:state/Dialogue", () => {
       expect(history[0].id).toEqual("tool-1");
     });
 
+    it("addToolMessage accepts content blocks", () => {
+      const dialogue = new Dialogue("main");
+      const content = [
+        { type: "text", text: "here it is" },
+        {
+          type: "image_url",
+          image_url: { url: "data:image/png;base64,iVBORw0KGgo=" },
+        },
+      ];
+      dialogue.addToolMessage(content, "myTool", "tool-1");
+      const history = dialogue.getHistory();
+      expect(history).toHaveLength(1);
+      assert(history[0].role === "function");
+      expect(history[0].content).toEqual(content);
+    });
+
     it("addToolCallMessage delegates to setToolCallMessage", () => {
       const dialogue = new Dialogue("main");
       dialogue.addToolCallMessage({
@@ -578,6 +594,22 @@ describe("llm-exe:state/Dialogue", () => {
       expect(history[0].role).toEqual("function");
       assert(history[0].role === "function");
       expect(history[0].name).toEqual("fn1");
+    });
+
+    it("addFunctionMessage accepts content blocks", () => {
+      const dialogue = new Dialogue("main");
+      const content = [
+        { type: "text", text: "result" },
+        {
+          type: "image_url",
+          image_url: { url: "data:image/png;base64,iVBORw0KGgo=" },
+        },
+      ];
+      dialogue.addFunctionMessage(content, "fn1", "fn-1");
+      const history = dialogue.getHistory();
+      expect(history).toHaveLength(1);
+      assert(history[0].role === "function");
+      expect(history[0].content).toEqual(content);
     });
 
     it("addFunctionCallMessage delegates to setFunctionCallMessage", () => {

--- a/src/state/dialogue.ts
+++ b/src/state/dialogue.ts
@@ -63,11 +63,19 @@ export class Dialogue extends BaseStateItem<IChatMessages> {
     return this;
   }
 
-  setToolMessage(content: string, name: string, id?: string) {
+  setToolMessage(
+    content: string | IChatMessageContentDetailed[],
+    name: string,
+    id?: string
+  ) {
     return this.setFunctionMessage(content, name, id);
   }
 
-  setFunctionMessage(content: string, name: string, id?: string) {
+  setFunctionMessage(
+    content: string | IChatMessageContentDetailed[],
+    name: string,
+    id?: string
+  ) {
     if (content) {
       this.value.push({
         role: "function",
@@ -172,7 +180,11 @@ export class Dialogue extends BaseStateItem<IChatMessages> {
     return this.setSystemMessage(content);
   }
 
-  addToolMessage(content: string, name: string, id?: string) {
+  addToolMessage(
+    content: string | IChatMessageContentDetailed[],
+    name: string,
+    id?: string
+  ) {
     return this.setToolMessage(content, name, id);
   }
 
@@ -180,7 +192,11 @@ export class Dialogue extends BaseStateItem<IChatMessages> {
     return this.setToolCallMessage(input);
   }
 
-  addFunctionMessage(content: string, name: string, id?: string) {
+  addFunctionMessage(
+    content: string | IChatMessageContentDetailed[],
+    name: string,
+    id?: string
+  ) {
     return this.setFunctionMessage(content, name, id);
   }
 


### PR DESCRIPTION
# Pull Request

## Description

Part of #757 — deliberately not `Fixes`. Replaces #759, which accumulated six review rounds; this is the same work with the final blocking item resolved, rebased clean onto current `development`, and verified against the live Anthropic API.

Widens `IChatFunctionMessage.content` to `string | IChatMessageContentDetailed[]` so a tool result can carry an image, and makes every provider either pass it through natively or throw a typed error instead of silently mangling it.

- **Types** — `IChatFunctionMessage.content` widened, with `addFunctionMessage`, the `addToPrompt("function", ...)` overload, and `Dialogue`'s `setFunctionMessage` / `setToolMessage` / `addFunctionMessage` / `addToolMessage` widened to match. Uses the same loose union user messages already accept, so a block valid on a user message is not rejected on a tool result.
- **`ChatPrompt.format()` / `formatAsync()`** — both templated function content unconditionally, so array content threw a raw Handlebars error before any provider config ran. Text blocks are templated; non-text blocks pass through.
- **Anthropic** — a content-block array now passes through as `tool_result.content` so images stay native. Previously `maybeStringifyJSON` flattened the already-converted array into a JSON string: the base64 was billed as text and the model still could not see it.
- **Google** — text-only block arrays flatten to a joined string; an image block throws `prompt.invalid_messages`, since `functionResponse.response` is a Struct with no image representation.
- **OpenAI-compatible** (`openai.chat`, `xai.chat`, `deepseek.chat`) — throws the same typed error for an image block in a tool result, before the `function` -> `tool` role flip.
- **Cross-provider contract** — an `"image tool result"` fixture forces all nine registered providers to declare pass-through-or-throw, so a new provider cannot reopen the hole silently.

### What changed since #759

The one blocking item from its final review: **`Array.isArray(content)` was too broad**. An arbitrary JSON array tool result was a working, deliberately-tested path (`maybeStringifyJSON` has explicit array coverage; Gemini's Struct takes one verbatim), and both providers regressed it into an Anthropic 400 / a Gemini throw.

Both branches now gate on a shared `isContentBlockArray()` (in `_utils/imageContent.ts`, beside the existing block helper), which requires every entry to carry a string `type` — matching `IChatMessageContentDetailed` exactly. Empty arrays keep the old path.

Also dropped #759's two agent run logs, which documented that PR's history rather than this change.

## Testing

**Live, end-to-end against the real Anthropic API** (dev harness, keys from SSM). A solid-purple PNG is generated by a hand-rolled encoder, sent *inside a tool result* through `createChatPrompt` -> `format()` -> `anthropic.claude-sonnet-5`, and the model is asked to name the dominant colour:

```
✓ prompt layer kept block array (no Handlebars throw) — 2 blocks
✓ Claude SAW the image and named the colour — "purple"
✓ plain JSON array tool result works — "alpha"
✓ typed JSON array tool result works — "delta"
```

(Re-run after the review fix tightened the predicate, since that change touched the image path.)

The model naming the colour is the proof that matters: it can only answer that if the image arrived as a native image block rather than base64 flattened into text.

**Control on `development`** (same code path, pre-fix): `format()` throws `You must pass a string or Handlebars AST to Handlebars.compile. You passed [object Object],[object Object]` — confirming the feature is genuinely new and not already working.

**Wire format verified per provider** by driving `format()` -> `mapBody` and inspecting the request body:

| Provider | Input | Body |
|---|---|---|
| Anthropic | image block | `{"type":"image","source":{"type":"base64",...}}` inside `tool_result.content` |
| Anthropic | `[{title:"a"},{title:"b"}]` | `"[{\"title\":\"a\"},{\"title\":\"b\"}]"` (identical to pre-PR) |
| Google | `[{title:"a"},{title:"b"}]` | verbatim in `functionResponse.response.result` |
| Google / OpenAI | image block | typed `prompt.invalid_messages` throw |

**Narrowing fix is mutation-verified:** reverting `isContentBlockArray` to `Array.isArray` fails exactly the 3 new Anthropic tests and exactly the 3 new Google tests, and nothing else.

6 regression tests added (the reviewer asked for 2), including the mixed-array case `[{type:"text",...},{title:"b"}]` — a partially-block array must still be treated as arbitrary JSON.

Full suite: **199 suites / 3125 tests pass**. `npm run typecheck` clean.

## Versioning

Labelled **minor** — backwards-compatible input-type widening. One wrinkle worth deciding deliberately rather than inheriting: `IChatFunctionMessage` is also a *read* type (`Dialogue.getHistory()` returns `IChatMessages`), so consumer code doing `if (m.role === "function") m.content.trim()` stops compiling until it narrows. I lean minor anyway, since `IChatUserMessage.content` already carries the same union and v3 shipped with it.

## Still open on #757

1. **Real Gemini multimodal `functionResponse`** — currently throws. The envelope varies by API version and could not be pinned from the repo; needs verifying against live Gemini docs before the throw becomes a conversion.
2. **Ollama role guard** (overlaps #706) — `ollamaPromptSanitize` branches on array content with no role check. The contract row records this as observed behavior, deliberately not as a guarantee.
3. **`openai.responses.v1`** — out of #757's scope, but the Responses API is where OpenAI actually ships image function-call output, and is the real fix for the OpenAI half rather than the throw added here.

## Accessibility Checklist

- [x] n/a — library source and tests only; no docs, UI, images, or interactive elements.

## Reviewers

Supersedes #759. All items from its six review rounds are addressed; the final blocking narrowing item is fixed, mutation-verified, and covered by per-provider regression tests.
